### PR TITLE
Patch inverted optional check.

### DIFF
--- a/src/transformers/__tests__/is-boolean.test.ts
+++ b/src/transformers/__tests__/is-boolean.test.ts
@@ -13,16 +13,18 @@ describe('IsBoolean', () => {
     });
     it('populates missing required fields with undefined', () => {
         class Fixture {
-            @IsBoolean({})
+            @IsBoolean()
             property!: boolean;
         }
 
         const obj = plainToClass(Fixture, {});
         expect(obj).toHaveProperty('property', undefined);
     });
-    it('populates null required fields with undefined', () => {
+    it('populates null optional fields with undefined', () => {
         class Fixture {
-            @IsBoolean({})
+            @IsBoolean({
+                optional: true,
+            })
             property!: boolean;
         }
 
@@ -33,7 +35,7 @@ describe('IsBoolean', () => {
     });
     it('populates undefined required fields with undefined', () => {
         class Fixture {
-            @IsBoolean({})
+            @IsBoolean()
             property!: boolean;
         }
 
@@ -57,7 +59,7 @@ describe('IsBoolean', () => {
     });
     it('populates true required fields with true', () => {
         class Fixture {
-            @IsBoolean({})
+            @IsBoolean()
             property!: boolean;
         }
 
@@ -68,7 +70,7 @@ describe('IsBoolean', () => {
     });
     it('populates truthy required fields with true', () => {
         class Fixture {
-            @IsBoolean({})
+            @IsBoolean()
             property!: boolean;
         }
 
@@ -79,7 +81,7 @@ describe('IsBoolean', () => {
     });
     it('populates false required fields with false', () => {
         class Fixture {
-            @IsBoolean({})
+            @IsBoolean()
             property!: boolean;
         }
 
@@ -90,7 +92,7 @@ describe('IsBoolean', () => {
     });
     it('populates falsey (false) required fields with false', () => {
         class Fixture {
-            @IsBoolean({})
+            @IsBoolean()
             property!: boolean;
         }
 
@@ -101,7 +103,7 @@ describe('IsBoolean', () => {
     });
     it('populates falsey (0) required fields with false', () => {
         class Fixture {
-            @IsBoolean({})
+            @IsBoolean()
             property!: boolean;
         }
 

--- a/src/transformers/__tests__/is-date-string.test.ts
+++ b/src/transformers/__tests__/is-date-string.test.ts
@@ -13,16 +13,18 @@ describe('IsDateString', () => {
     });
     it('populates missing required fields with undefined', () => {
         class Fixture {
-            @IsDateString({})
+            @IsDateString()
             property!: string;
         }
 
         const obj = plainToClass(Fixture, {});
         expect(obj).toHaveProperty('property', undefined);
     });
-    it('populates null required fields with undefined', () => {
+    it('populates null optional fields with undefined', () => {
         class Fixture {
-            @IsDateString({})
+            @IsDateString({
+                optional: true,
+            })
             property!: string;
         }
 
@@ -33,7 +35,7 @@ describe('IsDateString', () => {
     });
     it('populates undefined required fields with undefined', () => {
         class Fixture {
-            @IsDateString({})
+            @IsDateString()
             property!: string;
         }
 
@@ -57,7 +59,7 @@ describe('IsDateString', () => {
     });
     it('populates required fields with value', () => {
         class Fixture {
-            @IsDateString({})
+            @IsDateString()
             property!: string;
         }
 

--- a/src/transformers/__tests__/is-date.test.ts
+++ b/src/transformers/__tests__/is-date.test.ts
@@ -13,16 +13,18 @@ describe('IsDate', () => {
     });
     it('populates missing required fields with undefined', () => {
         class Fixture {
-            @IsDate({})
+            @IsDate()
             property!: Date;
         }
 
         const obj = plainToClass(Fixture, {});
         expect(obj).toHaveProperty('property', undefined);
     });
-    it('populates null required fields with undefined', () => {
+    it('populates null optional fields with undefined', () => {
         class Fixture {
-            @IsDate({})
+            @IsDate({
+                optional: true,
+            })
             property!: Date;
         }
 
@@ -33,7 +35,7 @@ describe('IsDate', () => {
     });
     it('populates undefined required fields with undefined', () => {
         class Fixture {
-            @IsDate({})
+            @IsDate()
             property!: Date;
         }
 
@@ -57,7 +59,7 @@ describe('IsDate', () => {
     });
     it('populates Date required fields with value', () => {
         class Fixture {
-            @IsDate({})
+            @IsDate()
             property!: Date;
         }
 
@@ -69,7 +71,7 @@ describe('IsDate', () => {
     });
     it('populates ISO string required fields with Date', () => {
         class Fixture {
-            @IsDate({})
+            @IsDate()
             property!: Date;
         }
 

--- a/src/transformers/__tests__/is-enun.test.ts
+++ b/src/transformers/__tests__/is-enun.test.ts
@@ -28,10 +28,11 @@ describe('IsEnum', () => {
         const obj = plainToClass(Fixture, {});
         expect(obj).toHaveProperty('property', undefined);
     });
-    it('populates null required fields with undefined', () => {
+    it('populates null optional fields with undefined', () => {
         class Fixture {
             @IsEnum({
                 enum: FixtureEnum,
+                optional: true,
             })
             property!: string;
         }

--- a/src/transformers/__tests__/is-integer.test.ts
+++ b/src/transformers/__tests__/is-integer.test.ts
@@ -13,16 +13,18 @@ describe('IsInteger', () => {
     });
     it('populates missing required fields with undefined', () => {
         class Fixture {
-            @IsInteger({})
+            @IsInteger()
             property!: number;
         }
 
         const obj = plainToClass(Fixture, {});
         expect(obj).toHaveProperty('property', undefined);
     });
-    it('populates null required fields with undefined', () => {
+    it('populates null optional fields with undefined', () => {
         class Fixture {
-            @IsInteger({})
+            @IsInteger({
+                optional: true,
+            })
             property!: number;
         }
 
@@ -33,7 +35,7 @@ describe('IsInteger', () => {
     });
     it('populates undefined required fields with undefined', () => {
         class Fixture {
-            @IsInteger({})
+            @IsInteger()
             property!: number;
         }
 
@@ -57,7 +59,7 @@ describe('IsInteger', () => {
     });
     it('populates string required fields with integer', () => {
         class Fixture {
-            @IsInteger({})
+            @IsInteger()
             property!: number;
         }
 
@@ -68,7 +70,7 @@ describe('IsInteger', () => {
     });
     it('populates number required fields with number', () => {
         class Fixture {
-            @IsInteger({})
+            @IsInteger()
             property!: number;
         }
 

--- a/src/transformers/__tests__/is-nested.test.ts
+++ b/src/transformers/__tests__/is-nested.test.ts
@@ -25,10 +25,11 @@ describe('IsNested', () => {
         const obj = plainToClass(Fixture, {});
         expect(obj).toHaveProperty('property', undefined);
     });
-    it('populates null required fields with undefined', () => {
+    it('populates null optional fields with undefined', () => {
         class Fixture {
             @IsNested({
                 type: Child,
+                optional: true,
             })
             property!: Child;
         }

--- a/src/transformers/__tests__/is-number.test.ts
+++ b/src/transformers/__tests__/is-number.test.ts
@@ -13,16 +13,18 @@ describe('IsNumber', () => {
     });
     it('populates missing required fields with undefined', () => {
         class Fixture {
-            @IsNumber({})
+            @IsNumber()
             property!: number;
         }
 
         const obj = plainToClass(Fixture, {});
         expect(obj).toHaveProperty('property', undefined);
     });
-    it('populates null required fields with undefined', () => {
+    it('populates null optional fields with undefined', () => {
         class Fixture {
-            @IsNumber({})
+            @IsNumber({
+                optional: true,
+            })
             property!: number;
         }
 
@@ -33,7 +35,7 @@ describe('IsNumber', () => {
     });
     it('populates undefined required fields with undefined', () => {
         class Fixture {
-            @IsNumber({})
+            @IsNumber()
             property!: number;
         }
 
@@ -57,7 +59,7 @@ describe('IsNumber', () => {
     });
     it('populates string required fields with number', () => {
         class Fixture {
-            @IsNumber({})
+            @IsNumber()
             property!: number;
         }
 
@@ -68,7 +70,7 @@ describe('IsNumber', () => {
     });
     it('populates number required fields with number', () => {
         class Fixture {
-            @IsNumber({})
+            @IsNumber()
             property!: number;
         }
 

--- a/src/transformers/__tests__/is-string.test.ts
+++ b/src/transformers/__tests__/is-string.test.ts
@@ -13,16 +13,18 @@ describe('IsString', () => {
     });
     it('populates missing required fields with undefined', () => {
         class Fixture {
-            @IsString({})
+            @IsString()
             property!: string;
         }
 
         const obj = plainToClass(Fixture, {});
         expect(obj).toHaveProperty('property', undefined);
     });
-    it('populates null required fields with undefined', () => {
+    it('populates null optional fields with undefined', () => {
         class Fixture {
-            @IsString({})
+            @IsString({
+                optional: true,
+            })
             property!: string;
         }
 
@@ -33,7 +35,7 @@ describe('IsString', () => {
     });
     it('populates undefined required fields with undefined', () => {
         class Fixture {
-            @IsString({})
+            @IsString()
             property!: string;
         }
 
@@ -57,7 +59,7 @@ describe('IsString', () => {
     });
     it('populates required fields with value', () => {
         class Fixture {
-            @IsString({})
+            @IsString()
             property!: string;
         }
 

--- a/src/transformers/__tests__/is-uuid.test.ts
+++ b/src/transformers/__tests__/is-uuid.test.ts
@@ -13,16 +13,18 @@ describe('IsUUID', () => {
     });
     it('populates missing required fields with undefined', () => {
         class Fixture {
-            @IsUUID({})
+            @IsUUID()
             property!: string;
         }
 
         const obj = plainToClass(Fixture, {});
         expect(obj).toHaveProperty('property', undefined);
     });
-    it('populates null required fields with undefined', () => {
+    it('populates null optional fields with undefined', () => {
         class Fixture {
-            @IsUUID({})
+            @IsUUID({
+                optional: true,
+            })
             property!: string;
         }
 
@@ -33,7 +35,7 @@ describe('IsUUID', () => {
     });
     it('populates undefined required fields with undefined', () => {
         class Fixture {
-            @IsUUID({})
+            @IsUUID()
             property!: string;
         }
 
@@ -57,7 +59,7 @@ describe('IsUUID', () => {
     });
     it('populates required fields with value', () => {
         class Fixture {
-            @IsUUID({})
+            @IsUUID()
             property!: string;
         }
 

--- a/src/transformers/base.ts
+++ b/src/transformers/base.ts
@@ -9,11 +9,11 @@ export function createBasePropertyDecorators({ name, nullable, optional }: BaseO
         // the (recommended) `forbidNonWhitelisted` settting.
         Expose({ name }),
 
-        // Ensure that `null` values are converted to `undefined` if values are non-optional; otherwise
+        // Ensure that `null` values are converted to `undefined` if values are optional; otherwise
         // certain checked using `typeof` may see `null` as `object` and misbehave.
         Transform(
             ({ value }: TransformFnParams) => (
-                (value === null && !nullable && !optional)
+                (value === null && !nullable && optional)
                     ? undefined
                     : value as unknown
             ),


### PR DESCRIPTION
The conversion logic was incorrectly ported for the null-to-optional case.

 - We explicitly do want to convert if the field is optional so that we won't
   value `null` as an object or return a `null` value (vs undefined).

 - We explicitly do not wantto convert if the field is not optional.

    - If the field is `null`, we want to keep the `null` value.
    - If the field is not-`null`, we want to fail on validation.