### PR TITLE
Port `pick` logic to class-decorators.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,6 @@ orbs:
           - run:
               name: Install dependencies
               command: yarn install
-      install-yarn:
-        steps:
-          - run:
-              name: Install yarn
-              command: |
-                sudo npm install -g -f yarn@latest
       release-library:
         steps:
           - run:
@@ -133,7 +127,6 @@ orbs:
         executor: << parameters.executor >>
         steps:
           - checkout
-          - install-yarn
           - restore-yarn-cache
           - install-dependencies
           - build-source

--- a/src/__tests__/__snapshots__/pick.test.ts.snap
+++ b/src/__tests__/__snapshots__/pick.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pick picks a single field and does not validate 1`] = `
+Array [
+  ValidationError {
+    "children": Array [],
+    "constraints": Object {
+      "isDefined": "foo should not be null or undefined",
+      "isString": "foo must be a string",
+    },
+    "property": "foo",
+    "target": ParentFixture {
+      "foo": undefined,
+    },
+    "value": undefined,
+  },
+]
+`;
+
+exports[`pick picks child fields and does not validate 1`] = `
+Array [
+  ValidationError {
+    "children": Array [],
+    "constraints": Object {
+      "isDefined": "child should not be null or undefined",
+    },
+    "property": "child",
+    "target": ParentFixture {
+      "child": undefined,
+    },
+    "value": undefined,
+  },
+]
+`;
+
+exports[`pick picks one field and one child field and does not validate if child is omitted 1`] = `
+Array [
+  ValidationError {
+    "children": Array [],
+    "constraints": Object {
+      "isDefined": "child should not be null or undefined",
+    },
+    "property": "child",
+    "target": ParentFixture {
+      "child": undefined,
+      "foo": "foo",
+    },
+    "value": undefined,
+  },
+]
+`;
+
+exports[`pick picks one field and one child field and does not validate if field is omitted 1`] = `
+Array [
+  ValidationError {
+    "children": Array [],
+    "constraints": Object {
+      "isDefined": "foo should not be null or undefined",
+      "isString": "foo must be a string",
+    },
+    "property": "foo",
+    "target": ParentFixture {
+      "child": ChildFixture {
+        "baz": "baz",
+      },
+      "foo": undefined,
+    },
+    "value": undefined,
+  },
+]
+`;

--- a/src/__tests__/pick.test.ts
+++ b/src/__tests__/pick.test.ts
@@ -1,0 +1,134 @@
+import { plainToClass } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+import { IsNested, IsString } from '../decorators';
+import { pick } from '../pick';
+
+describe('pick', () => {
+    class Child {
+        @IsString()
+        baz!: string;
+
+        @IsString()
+        qux!: string;
+    }
+
+    class Parent {
+        @IsString()
+        foo!: string;
+
+        @IsString()
+        bar!: string;
+
+        @IsNested({
+            type: Child,
+        })
+        child!: Child;
+    }
+
+    it('picks a single field and does not validate', () => {
+        const ParentFixture = pick(Parent, 'ParentFixture', ['foo']);
+
+        const obj = plainToClass(ParentFixture, {
+        });
+        const errors = validateSync(obj);
+        expect(errors).toHaveLength(1);
+        expect(errors).toMatchSnapshot();
+    });
+    it('picks a single field and validates', () => {
+        const ParentFixture = pick(Parent, 'ParentFixture', ['foo']);
+
+        const obj = plainToClass(ParentFixture, {
+            foo: 'foo',
+        });
+        const errors = validateSync(obj);
+        expect(errors).toHaveLength(0);
+    });
+    it('picks zero fields', () => {
+        const ParentFixture = pick(Parent, 'ParentFixture', []);
+
+        const obj = plainToClass(ParentFixture, {
+        });
+        const errors = validateSync(obj);
+        expect(errors).toHaveLength(0);
+    });
+    it('picks child fields and does not validate', () => {
+        const ParentFixture = pick(Parent, 'ParentFixture', ['child']);
+
+        const obj = plainToClass(ParentFixture, {
+        });
+        const errors = validateSync(obj);
+        expect(errors).toHaveLength(1);
+        expect(errors).toMatchSnapshot();
+    });
+    it('picks all child fields and validates', () => {
+        const ParentFixture = pick(Parent, 'ParentFixture', ['child']);
+
+        const obj = plainToClass(ParentFixture, {
+            child: {
+                baz: 'baz',
+                qux: 'sux',
+            },
+        });
+        const errors = validateSync(obj);
+        expect(errors).toHaveLength(0);
+    });
+    it('picks one field and one child field and does not validate if field is omitted', () => {
+        const ChildFixture = pick(Child, 'ChildFixture', ['baz']);
+        const ParentBase = pick(Parent, 'ParentBase', ['foo', 'child']);
+
+        class ParentFixture extends ParentBase {
+            @IsNested({
+                type: ChildFixture,
+            })
+            child!: Child; // THIS TYPE IS WRONG
+        }
+
+        const obj = plainToClass(ParentFixture, {
+            child: {
+                baz: 'baz',
+            },
+        });
+        const errors = validateSync(obj);
+        expect(errors).toHaveLength(1);
+        expect(errors).toMatchSnapshot();
+    });
+    it('picks one field and one child field and does not validate if child is omitted', () => {
+        const ChildFixture = pick(Child, 'ChildFixture', ['baz']);
+        const ParentBase = pick(Parent, 'ParentBase', ['foo', 'child']);
+
+        class ParentFixture extends ParentBase {
+            @IsNested({
+                type: ChildFixture,
+            })
+            child!: Child; // THIS TYPE IS WRONG
+        }
+
+        const obj = plainToClass(ParentFixture, {
+            foo: 'foo',
+        });
+        const errors = validateSync(obj);
+        expect(errors).toHaveLength(1);
+        expect(errors).toMatchSnapshot();
+    });
+    it('picks one field and one child field and validates', () => {
+        const ChildFixture = pick(Child, 'ChildFixture', ['baz']);
+        const ParentBase = pick(Parent, 'ParentBase', ['foo', 'child']);
+
+        class ParentFixture extends ParentBase {
+            @IsNested({
+                type: ChildFixture,
+            })
+            child!: Child; // THIS TYPE IS WRONG
+        }
+
+        const obj = plainToClass(ParentFixture, {
+            foo: 'foo',
+            child: {
+                baz: 'baz',
+            },
+        });
+        const errors = validateSync(obj);
+        expect(errors).toHaveLength(0);
+    });
+});

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -1,0 +1,35 @@
+import { Constructor, Target } from '@hippo-oss/dto-decorators';
+
+import { pickTransformerProperties } from './transformers';
+import { pickValidatorProperties } from './validators';
+
+/* Create a derived DTO class from the `Base` DTO class.
+ */
+export function derive<T extends Target>(
+    Base: Constructor<T>,
+    name: string,
+): Constructor<T> {
+    // NB: anonymous classes are named via their assigned variable
+    return {
+        [name]: class extends Base { },
+    }[name];
+}
+
+/* Create a derived class that narrows the `Base` class by picking fields.
+ */
+export function pick<T extends Target, F extends keyof T>(
+    Base: Constructor<T>,
+    name: string,
+    fields: F[],
+): Constructor<Pick<T, F>> {
+
+    const operators = [
+        pickTransformerProperties,
+        pickValidatorProperties,
+    ];
+
+    return operators.reduce(
+        (cls, operator) => operator(cls, fields),
+        derive(Base, name),
+    );
+}

--- a/src/transformers/index.ts
+++ b/src/transformers/index.ts
@@ -21,3 +21,5 @@ export const TRANSFORMER_DECORATORS: DTODecoratorFactories = {
     IsString,
     IsUUID,
 };
+
+export * from './pick';

--- a/src/transformers/pick.ts
+++ b/src/transformers/pick.ts
@@ -1,0 +1,38 @@
+import { Constructor, Target } from '@hippo-oss/dto-decorators';
+import { plainToClass, Exclude } from 'class-transformer';
+
+/* Return the available keys for a class.
+ *
+ * Because class members are assigned as part of the `constructor` function and TypeScript
+ * metadata is lost at runtime (unless `reflect-metadata` or similar is used), the only
+ * way to enumerate a class's members is to instantiate it, especially as `class-transformer`
+ * opts to implement its own `MetadataStorage` using a private/inaccessible implementation.
+ */
+function keysForClass<T extends Target>(cls: Constructor<T>): string[] {
+    // create a canary instance of the class so we can detect its fields
+    const canary = plainToClass(cls, {});
+
+    return Reflect.ownKeys(canary).filter(
+        (key: string | symbol): key is string => typeof key === 'string',
+    );
+}
+
+/* Narrow class-transformer properties by picking the provided fields.
+ */
+export function pickTransformerProperties<T extends Target, F extends keyof T>(
+    cls: Constructor<T>,
+    fields: F[],
+): Constructor<T> {
+
+    const decorator = Exclude();
+
+    // decorate each non-picked field as `@Exclude()`
+    for (const field of keysForClass(cls)) {
+        if (!fields.includes(field as F)) {
+            // eslint-disable-next-line @typescript-eslint/ban-types
+            decorator(cls.prototype as {}, field);
+        }
+    }
+
+    return cls;
+}

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -21,3 +21,5 @@ export const VALIDATOR_DECORATORS: DTODecoratorFactories = {
     IsString,
     IsUUID,
 };
+
+export * from './pick';

--- a/src/validators/pick.ts
+++ b/src/validators/pick.ts
@@ -1,0 +1,68 @@
+import { Constructor } from '@hippo-oss/dto-decorators';
+import { IsOptional, getMetadataStorage } from 'class-validator';
+
+/* Return the decorator properties of the given class.
+ */
+function propertiesForClass<T>(cls: Constructor<T>): string[] {
+    const metadata = getMetadataStorage();
+
+    const targetConstructor = cls;
+    // The underlying Validator passes `undefined` even though the schema is typed as `string`.
+    // See: https://github.com/typestack/class-validator/blob/develop/src/validation/Validator.ts#L100
+    const targetSchema = undefined as unknown as string;
+    const always = false;
+    const strictGroups = false;
+    const groups: string[] = [];
+
+    const validators = metadata.getTargetValidationMetadatas(
+        targetConstructor,
+        targetSchema,
+        always,
+        strictGroups,
+        groups,
+    );
+
+    return validators.map(
+        ({ propertyName }) => propertyName,
+    );
+}
+
+/* Narrow class-validator properties by picking the provided fields.
+ */
+export function omitValidatorProperties<T, F extends keyof T>(
+    cls: Constructor<T>,
+    fields: F[],
+): Constructor<T> {
+
+    const decorator = IsOptional();
+
+    /// decorate each omitted field as `@IsOptional()`
+    for (const field of fields) {
+        if (typeof field === 'string') {
+            // eslint-disable-next-line @typescript-eslint/ban-types
+            decorator(cls.prototype as {}, field);
+        }
+    }
+
+    return cls;
+}
+
+/* Narrow class-validator properties by omitting the provided fields.
+ */
+export function pickValidatorProperties<T, F extends keyof T>(
+    cls: Constructor<T>,
+    fields: F[],
+): Constructor<T> {
+
+    const decorator = IsOptional();
+
+    // decorate each non-picked field as `@IsOptional()`
+    for (const field of propertiesForClass(cls)) {
+        if (!fields.includes(field as F)) {
+            // eslint-disable-next-line @typescript-eslint/ban-types
+            decorator(cls.prototype as {}, field);
+        }
+    }
+
+    return cls;
+}


### PR DESCRIPTION
We have a very useful `pick` operator in `nest-dto` that enables taking a shared DTO
and picking a subset of fields. We have two goals here:

 1. Start to port the logic into the new decorator libraries so these operations can be used
    without coupling (e.g. to `@nestjs/swagger`)
 2. Improve the capabilities and test coverage of the operator.