### PR TITLE
allow pick to selectively ignore parent fields

### DIFF
--- a/src/pick.ts
+++ b/src/pick.ts
@@ -17,10 +17,11 @@ export function derive<T extends Target>(
 
 /* Create a derived class that narrows the `Base` class by picking fields.
  */
-export function pick<T extends Target, F extends keyof T>(
+export function pick<T extends Target, F extends keyof T, I extends keyof T>(
     Base: Constructor<T>,
     name: string,
     fields: F[],
+    ignoreFields: I[] = [],
 ): Constructor<Pick<T, F>> {
 
     const operators = [
@@ -29,7 +30,7 @@ export function pick<T extends Target, F extends keyof T>(
     ];
 
     return operators.reduce(
-        (cls, operator) => operator(cls, fields),
+        (cls, operator) => operator(cls, fields, ignoreFields),
         derive(Base, name),
     );
 }

--- a/src/transformers/pick.ts
+++ b/src/transformers/pick.ts
@@ -19,16 +19,17 @@ function keysForClass<T extends Target>(cls: Constructor<T>): string[] {
 
 /* Narrow class-transformer properties by picking the provided fields.
  */
-export function pickTransformerProperties<T extends Target, F extends keyof T>(
+export function pickTransformerProperties<T extends Target, F extends keyof T, I extends keyof T>(
     cls: Constructor<T>,
     fields: F[],
+    ignoreFields: I[] = [],
 ): Constructor<T> {
 
     const decorator = Exclude();
 
     // decorate each non-picked field as `@Exclude()`
     for (const field of keysForClass(cls)) {
-        if (!fields.includes(field as F)) {
+        if (!fields.includes(field as F) && !ignoreFields.includes(field as I)) {
             // eslint-disable-next-line @typescript-eslint/ban-types
             decorator(cls.prototype as {}, field);
         }

--- a/src/validators/pick.ts
+++ b/src/validators/pick.ts
@@ -49,16 +49,17 @@ export function omitValidatorProperties<T, F extends keyof T>(
 
 /* Narrow class-validator properties by omitting the provided fields.
  */
-export function pickValidatorProperties<T, F extends keyof T>(
+export function pickValidatorProperties<T, F extends keyof T, I extends keyof T>(
     cls: Constructor<T>,
     fields: F[],
+    ignoreFields: I[] = [],
 ): Constructor<T> {
 
     const decorator = IsOptional();
 
     // decorate each non-picked field as `@IsOptional()`
     for (const field of propertiesForClass(cls)) {
-        if (!fields.includes(field as F)) {
+        if (!fields.includes(field as F) && !ignoreFields.includes(field as I)) {
             // eslint-disable-next-line @typescript-eslint/ban-types
             decorator(cls.prototype as {}, field);
         }


### PR DESCRIPTION
The `pick()` operator is limited by the fact that `class-transformer` and `class-validator`
both obscure their decorator metadata, meaning that we cannot ask a class how it is decorated,
we can only modify its decoration via **additional** decorators.

While `dto-decorators` promises an alternative (because it supports saving decorator metadata
in our own storage), this solution-path is a bit longer than simply modifying the decorator
logic to ignore certain fields.

That is:

 - The return type to `pick()` is computed based on the provided `fields`.
 - The default behavior is that we mark every non-included field as either `@Exclude` or `@IsOptional`
 - The new behavior allows us to ignore certain fields that are not part of the returned type
   so we can extend them subsequently.